### PR TITLE
Remove executionModel from tutorial

### DIFF
--- a/backend/binaris.yml
+++ b/backend/binaris.yml
@@ -3,7 +3,6 @@ functions:
     file: functions.js
     entrypoint: createEndpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: &COMMON # for more info on yaml aliasing: https://github.com/cyklo/Bukkit-OtherBlocks/wiki/Aliases-(advanced-YAML-usage)
         REDIS_PORT:
@@ -13,20 +12,17 @@ functions:
     file: functions.js
     entrypoint: readEndpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
   public_update_endpoint:
     file: functions.js
     entrypoint: updateEndpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
   public_delete_endpoint:
     file: functions.js
     entrypoint: deleteEndpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON

--- a/frontend/serve_todo/binaris.yml
+++ b/frontend/serve_todo/binaris.yml
@@ -3,4 +3,3 @@ functions:
     file: function.js
     entrypoint: handler
     runtime: node8
-    executionModel: concurrent

--- a/tutorial_sections/build_a_crud.md
+++ b/tutorial_sections/build_a_crud.md
@@ -93,7 +93,7 @@ Then...
 ```bash
 $ mkdir backend
 $ cd backend
-$ bn create node8 public_create_endpoint --executionModel concurrent
+$ bn create node8 public_create_endpoint
 ```
 
 We will also rename our generated `function.js` file, since this will contain all four of our CRUD functions.
@@ -115,7 +115,6 @@ We'll update the `entrypoint` field of the function so it maps to the new functi
 -    entrypoint: handler
 +    entrypoint: create_endpoint
      runtime: node8
-     executionModel: concurrent
 ```
 
 Time to write our Redis CRUD code.
@@ -245,7 +244,6 @@ functions:
     file: functions.js
     entrypoint: create_endpoint
     runtime: node8
-    executionModel: concurrent
 ```
 
 </details> 
@@ -304,7 +302,6 @@ functions:
    file: src/create.js
    entrypoint: handler
    runtime: node8
-   executionModel: concurrent
 +  env:
 +    <<: &COMMON
 +      REDIS_HOST:
@@ -367,7 +364,6 @@ Time to create our other three functions. First, let's update our `binaris.yml` 
      file: functions.js
      entrypoint: create_endpoint
      runtime: node8
-     executionModel: concurrent
      env:
        <<: &COMMON
          REDIS_HOST:
@@ -377,21 +373,18 @@ Time to create our other three functions. First, let's update our `binaris.yml` 
 +    file: functions.js
 +    entrypoint: read_endpoint
 +    runtime: node8
-+    executionModel: concurrent
 +    env:
 +      <<: *COMMON
 +  public_update_endpoint:
 +    file: functions.js
 +    entrypoint: update_endpoint
 +    runtime: node8
-+    executionModel: concurrent
 +    env:
 +      <<: *COMMON
 +  public_delete_endpoint:
 +    file: functions.js
 +    entrypoint: delete_endpoint
 +    runtime: node8
-+    executionModel: concurrent
 +    env:
 +      <<: *COMMON
 ```
@@ -443,7 +436,6 @@ functions:
     file: functions.js
     entrypoint: create_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: &COMMON
         REDIS_HOST:
@@ -453,21 +445,18 @@ functions:
     file: functions.js
     entrypoint: read_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
   public_update_endpoint:
     file: functions.js
     entrypoint: update_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
   public_delete_endpoint:
     file: functions.js
     entrypoint: delete_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
 ```
@@ -635,7 +624,6 @@ functions:
     file: functions.js
     entrypoint: create_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: &COMMON
         REDIS_HOST:
@@ -645,21 +633,18 @@ functions:
     file: functions.js
     entrypoint: read_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
   public_update_endpoint:
     file: functions.js
     entrypoint: update_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
   public_delete_endpoint:
     file: functions.js
     entrypoint: delete_endpoint
     runtime: node8
-    executionModel: concurrent
     env:
       <<: *COMMON
 ```

--- a/tutorial_sections/serve_frontend.md
+++ b/tutorial_sections/serve_frontend.md
@@ -63,7 +63,7 @@ Navigate into the `serve_todo` directory and use `bn create` to generate the tem
 
 ```bash
 $ cd serve_todo
-$ bn create node8 public_serve_todo --executionModel concurrent
+$ bn create node8 public_serve_todo
 
 Created function public_serve_todo in /home/ubuntu/todo/frontend/serve_todo
   (use "bn deploy public_serve_todo" to deploy the function)


### PR DESCRIPTION
I've not yet propagated this into the specific release portions as I don't think it's needed for this change (the tutorial zip itself will contain the up to date version).